### PR TITLE
Add flint arrowhead and spearhead recycling recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for modded metals
 - **Container recycling for baskets and other storage items**
 
+## [1.2.1] - 2025-05-18
+
+### Added
+- Flint spearhead recycling: 1 flint spearhead → 3 flint chips
+- Flint arrowhead recycling: 2 flint arrowheads → 1 flint chip
+
 ## [1.2.0] - 2025-05-14
 
 ### Added

--- a/assets/recyclingtools/recipes/grid/flint_chips_recycling.json
+++ b/assets/recyclingtools/recipes/grid/flint_chips_recycling.json
@@ -82,5 +82,29 @@
     "output": { "type": "item", "code": "recyclingtools:flint_chips", "quantity": 1 },
     "name": "Salvage flint chips from crude arrows",
     "showInCreatedBy": true
+  },
+  {
+    "ingredientPattern": "H,R",
+    "ingredients": {
+      "H": { "type": "item", "code": "game:hammer-*", "isTool": true, "toolDurabilityCost": 10},
+      "R": { "type": "item", "code": "game:arrowhead-flint", "quantity": 2 }
+    },
+    "width": 1,
+    "height": 2,
+    "output": { "type": "item", "code": "recyclingtools:flint_chips", "quantity": 1 },
+    "name": "Salvage flint chips from arrowheads",
+    "showInCreatedBy": true
+  },
+  {
+    "ingredientPattern": "H,S",
+    "ingredients": {
+      "H": { "type": "item", "code": "game:hammer-*", "isTool": true, "toolDurabilityCost": 10},
+      "S": { "type": "item", "code": "game:spearhead-flint", "quantity": 1 }
+    },
+    "width": 1,
+    "height": 2,
+    "output": { "type": "item", "code": "recyclingtools:flint_chips", "quantity": 3 },
+    "name": "Salvage flint chips from spearheads",
+    "showInCreatedBy": true
   }
 ]

--- a/modinfo.json
+++ b/modinfo.json
@@ -3,7 +3,7 @@
   "side": "universal",
   "modid": "recyclingtools",
   "name": "Recycling Tools",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Allows dismantling and recycling of old tools, starting with helve hammers. Recover metal from outdated equipment!",
   "authors": ["Potusek"],
   "dependencies": {


### PR DESCRIPTION
- Added recipe to salvage flint chips from flint arrowheads (2 arrowheads → 1 chip)
- Added recipe to salvage flint chips from flint spearheads (1 spearhead → 3 chips)
- Updated CHANGELOG.md with the new recipes
- Completes the flint recycling system by covering all flint items in the game