### PR TITLE
Fix tool dismantling issues with copper hammers and missing spear recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Container recycling for baskets and other storage items**
 - Recipe adaptation based on tool durability (more recovery for less worn tools)
 
+## [1.3.1] - 2025-06-15
+
+### Fixed
+- Fixed missing copper variant in hammer dismantling recipe - copper hammers can now be dismantled
+- Added missing spear dismantling recipe to recover spearheads  
+- **Fixed axe disappearing when dismantling hammers and helve hammers** - axes now properly lose durability instead of being consumed
+- All basic metal tools can now be properly dismantled and recycled
+
+### Technical
+- Added missing `isTool: true` and `toolDurabilityCost` properties to hammer dismantling recipes
+- Ensured consistent tool behavior across all dismantling operations
+
 ## [1.3.0] - 2025-05-22
 
 ### Added

--- a/assets/recyclingtools/recipes/grid/tool_dismantling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling.json
@@ -41,8 +41,8 @@
   {
     "ingredientPattern": "A,T",
     "ingredients": {
-      "A": {"type": "item", "code": "game:axe-*" },
-      "T": {"type": "item", "code": "game:hammer-*", "name": "metal", "allowedVariants": ["tinbronze", "bismuthbronze", "blackbronze", "iron", "meteoriciron", "steel"] }
+      "A": {"type": "item", "code": "game:axe-*", "isTool": true, "toolDurabilityCost": 5 },
+      "T": {"type": "item", "code": "game:hammer-*", "name": "metal", "allowedVariants": ["copper", "tinbronze", "bismuthbronze", "blackbronze", "iron", "meteoriciron", "steel"] }
     },
     "width": 1,
     "height": 2,
@@ -53,7 +53,7 @@
   {
     "ingredientPattern": "A,T",
     "ingredients": {
-      "A": {"type": "item", "code": "game:axe-*" },
+      "A": {"type": "item", "code": "game:axe-*", "isTool": true, "toolDurabilityCost": 5 },
       "T": {"type": "item", "code": "game:helvehammer-*", "name": "metal", "allowedVariants": ["tinbronze", "bismuthbronze", "blackbronze", "iron", "meteoriciron", "steel"] }
     },
     "width": 1,
@@ -164,6 +164,19 @@
     "height": 2,
     "output": {"type": "item", "code": "game:bladehead-short-{metal}", "quantity": 1, "transferDurability": true },
     "name": "Dismantle knife to recover blade",
+    "shapeless": true,
+    "showInCreatedBy": true
+  },
+  {
+    "ingredientPattern": "A,N",
+    "ingredients": {
+      "A": {"type": "item", "code": "game:axe-*", "isTool": true, "toolDurabilityCost": 5 },
+      "N": {"type": "item", "code": "game:spear-generic-*", "name": "metal", "allowedVariants": ["copper", "tinbronze", "bismuthbronze", "blackbronze"]}
+    },
+    "width": 1,
+    "height": 2,
+    "output": {"type": "item", "code": "game:spearhead-{metal}", "quantity": 1, "transferDurability": true },
+    "name": "Dismantle spear to recover spearhead",
     "shapeless": true,
     "showInCreatedBy": true
   }

--- a/modinfo.json
+++ b/modinfo.json
@@ -3,7 +3,7 @@
   "side": "universal",
   "modid": "recyclingtools",
   "name": "Recycling Tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Allows dismantling and recycling of old tools, starting with helve hammers. Recover metal from outdated equipment!",
   "authors": ["Potusek"],
   "dependencies": {


### PR DESCRIPTION
- Add copper to allowedVariants in hammer dismantling recipes
- Add missing spear dismantling recipe to recover spearheads
- Fix axes disappearing when dismantling hammers by adding missing isTool properties
- Add proper toolDurabilityCost to hammer and helve hammer dismantling recipes

Fixes: Axes now properly lose durability instead of being consumed
Fixes: Copper hammers can now be dismantled like other metal hammers
Adds: Complete spear recycling workflow (dismantle → salvage metal bits)