### PR TITLE
feat: add recipe grouping and stonepath splitting recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Container recycling for baskets and other storage items**
 - Recipe adaptation based on tool durability (more recovery for less worn tools)
 
-# Changelog Entry for v1.4.0
+## [1.4.1] - 2025-06-23
+
+### Added
+- **Stonepath splitting recipes**: Convert full stone paths into slabs using shovels
+  - Premium option: shovel + soil + stonepath → 2 slabs (no material loss)
+  - Budget option: shovel + stonepath → 1 slab (50% material loss)
+- **Recipe grouping system**: All recycling recipes now grouped by tool type for better UI organization
+
+### Improved
+- **Enhanced UI experience**: Recipes are now logically grouped in the crafting interface
+  - Group 1320: Copper chisel recipes
+  - Group 1321: Bronze chisel recipes  
+  - Group 1322: Iron chisel recipes
+  - Group 1323: Steel chisel recipes
+- **Better recipe discoverability**: Players can easily see all available options for each tool type
+- **Cleaner crafting interface**: Reduced clutter by grouping related recipes together
+
+### Technical
+- Added `recipeGroup` properties to all recycling recipes for consistent UI presentation
+- Organized recipes by tool compatibility rather than output type
 
 ## [1.4.0] - 2025-06-18
 

--- a/assets/recyclingtools/recipes/grid/backpack_recycling.json
+++ b/assets/recyclingtools/recipes/grid/backpack_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "S,L",
+    "recipeGroup": 1340,
     "ingredients": {
       "S": { "type": "item", "code": "game:shears-*", "isTool": true, "toolDurabilityCost": 10},
       "L": { "type": "item", "code": "game:backpack-normal" }
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "K,L",
+    "recipeGroup": 1340,
     "ingredients": {
       "K": { "type": "item", "code": "game:knife-*", "isTool": true, "toolDurabilityCost": 15},
       "L": { "type": "item", "code": "game:backpack-normal" }
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "S,L",
+    "recipeGroup": 1340,
     "ingredients": {
       "S": { "type": "item", "code": "game:shears-*", "isTool": true, "toolDurabilityCost": 10},
       "L": { "type": "item", "code": "game:backpack-sturdy" }
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "K,L",
+    "recipeGroup": 1340,
     "ingredients": {
       "K": { "type": "item", "code": "game:knife-*", "isTool": true, "toolDurabilityCost": 15},
       "L": { "type": "item", "code": "game:backpack-sturdy" }

--- a/assets/recyclingtools/recipes/grid/hunterbackpack_recycling.json
+++ b/assets/recyclingtools/recipes/grid/hunterbackpack_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "S,L",
+    "recipeGroup": 1341,
     "ingredients": {
       "S": { "type": "item", "code": "game:shears-*", "isTool": true, "toolDurabilityCost": 10},
       "L": { "type": "item", "code": "game:hunterbackpack" }
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "K,L",
+    "recipeGroup": 1341,
     "ingredients": {
       "K": { "type": "item", "code": "game:knife-*", "isTool": true, "toolDurabilityCost": 15},
       "L": { "type": "item", "code": "game:hunterbackpack" }

--- a/assets/recyclingtools/recipes/grid/recycling-stonepathslab.json
+++ b/assets/recyclingtools/recipes/grid/recycling-stonepathslab.json
@@ -1,0 +1,31 @@
+[
+  {
+    "ingredientPattern": "B DS",
+    "recipeGroup": 1313,
+    "ingredients": {
+      "B": {"type": "item", "code": "game:shovel-*", "isTool": true, "toolDurabilityCost": 5},
+      "D": {"type": "block", "code": "game:soil-*", "quantity": 1},
+      "S": { "type": "block", "code": "game:stonepath-free", "quantity": 1}
+    },
+    "width": 2,
+    "height": 2,
+    "output": { "type": "block", "code": "game:stonepathslab-free", "quantity": 2},
+    "name": "Stonepath to slab",
+    "shapeless": true,
+    "showInCreatedBy": true
+  },
+  {
+    "ingredientPattern": "B,S",
+    "recipeGroup": 1323,
+    "ingredients": {
+      "B": {"type": "item", "code": "game:shovel-*", "isTool": true, "toolDurabilityCost": 5},
+      "S": { "type": "block", "code": "game:stonepath-free", "quantity": 1}
+    },
+    "width": 1,
+    "height": 2,
+    "output": { "type": "block", "code": "game:stonepathslab-free", "quantity": 1},
+    "name": "Stonepath to slab",
+    "shapeless": true,
+    "showInCreatedBy": true
+  }
+]

--- a/assets/recyclingtools/recipes/grid/scrap_to_metalbit.json
+++ b/assets/recyclingtools/recipes/grid/scrap_to_metalbit.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "SS",
+    "recipeGroup": 1313,
     "ingredients": {
       "S": {"type": "item", "code": "recyclingtools:metalscrap-*", "name": "metal", "allowedVariants": ["silver", "gold", "copper", "tinbronze", "bismuthbronze", "blackbronze", "iron", "meteoriciron", "steel"]}
     },

--- a/assets/recyclingtools/recipes/grid/tool_dismantling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "A,T",
+    "recipeGroup": 1313,
     "ingredients": {
       "A": {"type": "item", "code": "game:axe-*", "isTool": true, "toolDurabilityCost": 5 },
       "T": {"type": "item", "code": "game:helvehammer-*", "name": "metal", "allowedVariants": ["tinbronze", "bismuthbronze", "blackbronze", "iron", "meteoriciron", "steel"] }

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/arrow_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/arrow_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:arrow-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:arrow-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item", "code": "game:arrow-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:arrow-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/axe_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/axe_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 6, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/blade-falx_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/blade-falx_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:blade-falx-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:blade-falx-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item", "code": "game:blade-falx-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:blade-falx-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/blade-short_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/blade-short_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:blade-short-*", "name": "metal", "allowedVariants": ["iron"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item", "code": "game:blade-short-*", "name": "metal", "allowedVariants": ["iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:blade-short-*", "name": "metal", "allowedVariants": ["iron"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/cleaver_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/cleaver_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:cleaver-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:cleaver-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item", "code": "game:cleaver-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:cleaver-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/hammer_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/hammer_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:hammer-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:hammer-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:hammer-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:hammer-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/hoe_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/hoe_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:hoe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:hoe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:hoe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:hoe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/knifeblade_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/knifeblade_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:knifeblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:knifeblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:knifeblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:knifeblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/pickaxe_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/pickaxe_recycling.json
@@ -1,6 +1,7 @@
 [
   {
-    "ingredientPattern": "C  B",
+    "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:pickaxe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -13,7 +14,8 @@
     "showInCreatedBy": true
   },
   {
-    "ingredientPattern": "C  B",
+    "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:pickaxe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -26,7 +28,8 @@
     "showInCreatedBy": true
   },
   {
-    "ingredientPattern": "C  B",
+    "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:pickaxe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -39,7 +42,8 @@
     "showInCreatedBy": true
   },
   {
-    "ingredientPattern": "C  B",
+    "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:pickaxe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/prospectingpick_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/prospectingpick_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/sawblade_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/sawblade_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/scythehead_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/scythehead_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/shovel_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/shovel_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:shovel-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:shovel-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:shovel-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:shovel-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/spear_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/spear_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -16,6 +17,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -29,6 +31,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -42,6 +45,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/wrench_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/wrench_recycling.json
@@ -1,6 +1,7 @@
 [
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
       "B": {"type": "item", "code": "game:wrench-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
@@ -14,6 +15,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
       "B": {"type": "item", "code": "game:wrench-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
@@ -27,6 +29,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
       "B": {"type": "item","code": "game:wrench-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
@@ -40,6 +43,7 @@
   },
   {
     "ingredientPattern": "C,B",
+    "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
       "B": {"type": "item", "code": "game:wrench-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}

--- a/modinfo.json
+++ b/modinfo.json
@@ -3,7 +3,7 @@
   "side": "universal",
   "modid": "recyclingtools",
   "name": "Recycling Tools",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Allows dismantling and recycling of old tools, starting with helve hammers. Recover metal from outdated equipment!",
   "authors": ["Potusek"],
   "dependencies": {


### PR DESCRIPTION
- Group all recycling recipes by chisel type (1320-1323) for better UI
- Add stonepath-to-slab conversion with two options:
  * Premium: shovel + soil + path → 2 slabs (balanced)
  * Budget: shovel + path → 1 slab (material loss)
- Improve crafting interface organization and discoverability
- Maintain backward compatibility with all existing recipes

Resolves recipe UI clutter and adds requested stonepath functionality