### PR TITLE
fix: correct tool item codes in recycling recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Container recycling for baskets and other storage items**
 - Recipe adaptation based on tool durability (more recovery for less worn tools)
 
+## [1.4.2] - 2025-06-23
+
+### Fixed
+- Fixed incorrect item codes in tool recycling recipes
+- Corrected recipe files to use complete tool names instead of tool parts
+- Fixed recipes for axes, saws, scythes, spears, and knives
+- Ensured all tool recycling recipes load properly without errors
+
+### Technical
+- Renamed recipe files to match actual in-game tool codes
+- Updated from tool parts (axehead, sawblade) to complete tools (axe-felling, saw)
+
 ## [1.4.1] - 2025-06-23
 
 ### Added

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/axe-felling_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/axe-felling_recycling.json
@@ -4,12 +4,12 @@
     "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
-      "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
+      "B": {"type": "item", "code": "game:axe-felling-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle axe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -17,13 +17,13 @@
     "ingredientPattern": "C,B",
     "recipeGroup": 1321,
     "ingredients": {
-      "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
-      "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
+      "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 6, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
+      "B": {"type": "item", "code": "game:axe-felling-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle axe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -32,12 +32,12 @@
     "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
-      "B": {"type": "item","code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item", "code": "game:axe-felling-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle axe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -45,13 +45,13 @@
     "ingredientPattern": "C,B",
     "recipeGroup": 1323,
     "ingredients": {
-      "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
-      "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
+      "B": {"type": "item", "code": "game:axe-felling-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 8},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle axe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   }

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/knife-generic_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/knife-generic_recycling.json
@@ -4,12 +4,12 @@
     "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
-      "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
+      "B": {"type": "item", "code": "game:knife-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle axe into scrap bits",
+    "name": "Recycle knife into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -18,12 +18,12 @@
     "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 6, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
-      "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
+      "B": {"type": "item", "code": "game:knife-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle axe into scrap bits",
+    "name": "Recycle knife into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -32,12 +32,12 @@
     "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
-      "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item", "code": "game:knife-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle axe into scrap bits",
+    "name": "Recycle knife into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -46,12 +46,12 @@
     "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
-      "B": {"type": "item", "code": "game:axe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item", "code": "game:knife-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 8},
-    "name": "Recycle axe into scrap bits",
+    "name": "Recycle knife into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   }

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/saw_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/saw_recycling.json
@@ -4,12 +4,12 @@
     "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
-      "B": {"type": "item", "code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
+      "B": {"type": "item", "code": "game:saw-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
     },
     "width": 1,
     "height": 2,
-    "output": {"type": "item", "code": "game:metalbit-{metal}", "quantity": 6},
-    "name": "Recycle sawblade into metal bits",
+    "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
+    "name": "Recycle saw into metal bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -18,12 +18,12 @@
     "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
-      "B": {"type": "item", "code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
+      "B": {"type": "item", "code": "game:saw-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
     },
     "width": 1,
     "height": 2,
-    "output": {"type": "item", "code": "game:metalbit-{metal}", "quantity": 6},
-    "name": "Recycle sawblade into metal bits",
+    "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
+    "name": "Recycle saw into metal bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -32,12 +32,12 @@
     "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
-      "B": {"type": "item","code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item","code": "game:saw-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
-    "output": {"type": "item", "code": "game:metalbit-{metal}", "quantity": 6},
-    "name": "Recycle sawblade into metal bits",
+    "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
+    "name": "Recycle saw into metal bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -46,12 +46,12 @@
     "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
-      "B": {"type": "item", "code": "game:sawblade-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item", "code": "game:saw-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
-    "output": {"type": "item", "code": "game:metalbit-{metal}", "quantity": 8},
-    "name": "Recycle sawblade into metal bits",
+    "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 8},
+    "name": "Recycle saw into metal bits",
     "shapeless": true,
     "showInCreatedBy": true
   }

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/scythe_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/scythe_recycling.json
@@ -4,14 +4,12 @@
     "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
-      "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
+      "B": {"type": "item", "code": "game:scythe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
     },
     "width": 1,
     "height": 2,
-    "output": {
-      "type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6
-    },
-    "name": "Recycle spear into scrap bits",
+    "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
+    "name": "Recycle scythe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -20,12 +18,12 @@
     "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
-      "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
+      "B": {"type": "item", "code": "game:scythe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle scythe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -34,12 +32,12 @@
     "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
-      "B": {"type": "item","code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item","code": "game:scythe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle scythe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -48,12 +46,12 @@
     "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
-      "B": {"type": "item", "code": "game:spear-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item", "code": "game:scythe-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 8},
-    "name": "Recycle spear into scrap bits",
+    "name": "Recycle scythe into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   }

--- a/assets/recyclingtools/recipes/grid/tool_dismantling/spear-generic_recycling.json
+++ b/assets/recyclingtools/recipes/grid/tool_dismantling/spear-generic_recycling.json
@@ -4,12 +4,14 @@
     "recipeGroup": 1320,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["copper"]},
-      "B": {"type": "item", "code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
+      "B": {"type": "item", "code": "game:spear-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze"]}
     },
     "width": 1,
     "height": 2,
-    "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle prospectingpick into scrap bits",
+    "output": {
+      "type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6
+    },
+    "name": "Recycle spear into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -18,12 +20,12 @@
     "recipeGroup": 1321,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["tinbronze","bismuthbronze","blackbronze"]},
-      "B": {"type": "item", "code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
+      "B": {"type": "item", "code": "game:spear-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle prospectingpick into scrap bits",
+    "name": "Recycle spear into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -32,12 +34,12 @@
     "recipeGroup": 1322,
     "ingredients": {
       "C": {"type": "item", "code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 5, "allowedVariants": ["iron","meteoriciron"]},
-      "B": {"type": "item","code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item","code": "game:spear-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 6},
-    "name": "Recycle prospectingpick into scrap bits",
+    "name": "Recycle spear into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   },
@@ -46,12 +48,12 @@
     "recipeGroup": 1323,
     "ingredients": {
       "C": {"type": "item","code": "game:chisel-*", "isTool": true, "toolDurabilityCost": 2, "allowedVariants": ["steel"]},
-      "B": {"type": "item", "code": "game:prospectingpick-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
+      "B": {"type": "item", "code": "game:spear-generic-*", "name": "metal", "allowedVariants": ["silver","gold","copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}
     },
     "width": 1,
     "height": 2,
     "output": {"type": "item", "code": "recyclingtools:metalscrap-{metal}", "quantity": 8},
-    "name": "Recycle prospectingpick into scrap bits",
+    "name": "Recycle spear into scrap bits",
     "shapeless": true,
     "showInCreatedBy": true
   }

--- a/modinfo.json
+++ b/modinfo.json
@@ -3,7 +3,7 @@
   "side": "universal",
   "modid": "recyclingtools",
   "name": "Recycling Tools",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Allows dismantling and recycling of old tools, starting with helve hammers. Recover metal from outdated equipment!",
   "authors": ["Potusek"],
   "dependencies": {


### PR DESCRIPTION
- Fix axe-felling, saw, scythe, spear-generic, knife-generic recipe codes
- Remove obsolete recipes using tool part names instead of complete tools
- Ensure all tool recycling recipes load without errors